### PR TITLE
Add relative paths for prompt loader

### DIFF
--- a/libs/core/langchain_core/prompts/loading.py
+++ b/libs/core/langchain_core/prompts/loading.py
@@ -1,4 +1,5 @@
 """Load prompts."""
+
 import json
 import logging
 from pathlib import Path
@@ -17,7 +18,9 @@ URL_BASE = "https://raw.githubusercontent.com/hwchase17/langchain-hub/master/pro
 logger = logging.getLogger(__name__)
 
 
-def load_prompt_from_config(config: dict, template_base_path: Optional[Union[str, Path]] = None) -> BasePromptTemplate:
+def load_prompt_from_config(
+    config: dict, template_base_path: Optional[Union[str, Path]] = None
+) -> BasePromptTemplate:
     """Load prompt from Config Dict."""
     if "_type" not in config:
         logger.warning("No `_type` key found, defaulting to `prompt`.")
@@ -30,7 +33,9 @@ def load_prompt_from_config(config: dict, template_base_path: Optional[Union[str
     return prompt_loader(config, template_base_path)
 
 
-def _load_template(var_name: str, config: dict, template_base_path: Optional[Path] = None) -> dict:
+def _load_template(
+    var_name: str, config: dict, template_base_path: Optional[Path] = None
+) -> dict:
     """Load template from the path if applicable."""
     # Check if template_path exists in config.
     if f"{var_name}_path" in config:
@@ -109,7 +114,9 @@ def _load_few_shot_prompt(config: dict) -> FewShotPromptTemplate:
     return FewShotPromptTemplate(**config)
 
 
-def _load_prompt(config: dict, template_base_path: Optional[Union[str, Path]] = None) -> PromptTemplate:
+def _load_prompt(
+    config: dict, template_base_path: Optional[Union[str, Path]] = None
+) -> PromptTemplate:
     """Load the prompt template from config."""
     # Load the template from disk if necessary.
     config = _load_template("template", config, template_base_path)
@@ -128,7 +135,9 @@ def _load_prompt(config: dict, template_base_path: Optional[Union[str, Path]] = 
     return PromptTemplate(**config)
 
 
-def load_prompt(path: Union[str, Path], template_base_path: Optional[Union[str, Path]] = None) -> BasePromptTemplate:
+def load_prompt(
+    path: Union[str, Path], template_base_path: Optional[Union[str, Path]] = None
+) -> BasePromptTemplate:
     """Unified method for loading a prompt from LangChainHub or local fs."""
     if hub_result := try_load_from_hub(
         path, _load_prompt_from_file, "prompts", {"py", "json", "yaml"}
@@ -138,7 +147,9 @@ def load_prompt(path: Union[str, Path], template_base_path: Optional[Union[str, 
         return _load_prompt_from_file(path, template_base_path)
 
 
-def _load_prompt_from_file(file: Union[str, Path], template_base_path: Optional[Union[str, Path]] = None) -> BasePromptTemplate:
+def _load_prompt_from_file(
+    file: Union[str, Path], template_base_path: Optional[Union[str, Path]] = None
+) -> BasePromptTemplate:
     """Load prompt from file."""
     # Convert file to a Path object.
     if isinstance(file, str):

--- a/libs/core/langchain_core/prompts/loading.py
+++ b/libs/core/langchain_core/prompts/loading.py
@@ -2,7 +2,7 @@
 import json
 import logging
 from pathlib import Path
-from typing import Callable, Dict, Union
+from typing import Callable, Dict, Optional, Union
 
 import yaml
 
@@ -17,7 +17,7 @@ URL_BASE = "https://raw.githubusercontent.com/hwchase17/langchain-hub/master/pro
 logger = logging.getLogger(__name__)
 
 
-def load_prompt_from_config(config: dict) -> BasePromptTemplate:
+def load_prompt_from_config(config: dict, template_base_path: Optional[Union[str, Path]] = None) -> BasePromptTemplate:
     """Load prompt from Config Dict."""
     if "_type" not in config:
         logger.warning("No `_type` key found, defaulting to `prompt`.")
@@ -27,10 +27,10 @@ def load_prompt_from_config(config: dict) -> BasePromptTemplate:
         raise ValueError(f"Loading {config_type} prompt not supported")
 
     prompt_loader = type_to_loader_dict[config_type]
-    return prompt_loader(config)
+    return prompt_loader(config, template_base_path)
 
 
-def _load_template(var_name: str, config: dict) -> dict:
+def _load_template(var_name: str, config: dict, template_base_path: Optional[Path] = None) -> dict:
     """Load template from the path if applicable."""
     # Check if template_path exists in config.
     if f"{var_name}_path" in config:
@@ -41,6 +41,9 @@ def _load_template(var_name: str, config: dict) -> dict:
             )
         # Pop the template path from the config.
         template_path = Path(config.pop(f"{var_name}_path"))
+        # if base path is provided, join the path with it.
+        if template_base_path:
+            template_path = template_base_path / template_path
         # Load the template.
         if template_path.suffix == ".txt":
             with open(template_path) as f:
@@ -106,10 +109,10 @@ def _load_few_shot_prompt(config: dict) -> FewShotPromptTemplate:
     return FewShotPromptTemplate(**config)
 
 
-def _load_prompt(config: dict) -> PromptTemplate:
+def _load_prompt(config: dict, template_base_path: Optional[Union[str, Path]] = None) -> PromptTemplate:
     """Load the prompt template from config."""
     # Load the template from disk if necessary.
-    config = _load_template("template", config)
+    config = _load_template("template", config, template_base_path)
     config = _load_output_parser(config)
 
     template_format = config.get("template_format", "f-string")
@@ -125,17 +128,17 @@ def _load_prompt(config: dict) -> PromptTemplate:
     return PromptTemplate(**config)
 
 
-def load_prompt(path: Union[str, Path]) -> BasePromptTemplate:
+def load_prompt(path: Union[str, Path], template_base_path: Optional[Union[str, Path]] = None) -> BasePromptTemplate:
     """Unified method for loading a prompt from LangChainHub or local fs."""
     if hub_result := try_load_from_hub(
         path, _load_prompt_from_file, "prompts", {"py", "json", "yaml"}
     ):
         return hub_result
     else:
-        return _load_prompt_from_file(path)
+        return _load_prompt_from_file(path, template_base_path)
 
 
-def _load_prompt_from_file(file: Union[str, Path]) -> BasePromptTemplate:
+def _load_prompt_from_file(file: Union[str, Path], template_base_path: Optional[Union[str, Path]] = None) -> BasePromptTemplate:
     """Load prompt from file."""
     # Convert file to a Path object.
     if isinstance(file, str):
@@ -152,7 +155,7 @@ def _load_prompt_from_file(file: Union[str, Path]) -> BasePromptTemplate:
     else:
         raise ValueError(f"Got unsupported file type {file_path.suffix}")
     # Load the prompt from the config now.
-    return load_prompt_from_config(config)
+    return load_prompt_from_config(config, template_base_path)
 
 
 def _load_chat_prompt(config: Dict) -> ChatPromptTemplate:


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [ ] **PR title**: langchain-core: add relative path support for template paths in load_prompt

- [ ] **PR message**:
    - **Description:** This PR adds a template_base_path parameter (Optional[Union[str, Path]]) to various prompt loading functions in the langchain_core library, enabling dynamic resolution of template paths. This enhances flexibility for scenarios with non-standard directory structures or different environment setups. Changes are backward compatible with the optional function arguments.
    - **Dependencies:** No change

- [ ] **Lint and test**: done

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, hwchase17.
